### PR TITLE
Add a bit of flexibility on Slack notifications.

### DIFF
--- a/src/commands/deployomat-cancel-on-hold-message.yml
+++ b/src/commands/deployomat-cancel-on-hold-message.yml
@@ -9,6 +9,10 @@ parameters:
     type: "string"
     description: "Name of the service being deployed"
     default: ""
+  header_type:
+    type: "string"
+    description: "The type specifier for the block indicating what's happening"
+    default: "header"
 
 steps:
   - run:
@@ -24,7 +28,7 @@ steps:
             \"text\": \"${HEADER}\",
             \"blocks\": [
               {
-                \"type\": \"header\",
+                \"type\": \"<< parameters.header_type >>\",
                 \"text\": {
                   \"type\": \"plain_text\",
                   \"text\": \"${HEADER} :octagonal_sign::no_good: \",

--- a/src/commands/deployomat-deploy-on-hold-message.yml
+++ b/src/commands/deployomat-deploy-on-hold-message.yml
@@ -9,6 +9,10 @@ parameters:
     type: "string"
     description: "Name of the service being deployed"
     default: ""
+  header_type:
+    type: "string"
+    description: "The type specifier for the block indicating what's happening"
+    default: "header"
 
 steps:
   - run:
@@ -24,7 +28,7 @@ steps:
             \"text\": \"${HEADER}\",
             \"blocks\": [
               {
-                \"type\": \"header\",
+                \"type\": \"<< parameters.header_type >>\",
                 \"text\": {
                   \"type\": \"plain_text\",
                   \"text\": \"${HEADER} :fireworks:\",

--- a/src/commands/terraform-slack-on-hold-message.yml
+++ b/src/commands/terraform-slack-on-hold-message.yml
@@ -10,6 +10,11 @@ parameters:
     description: "Environment variable name to export our template to."
     default: "TEAK_TF_ON_HOLD"
 
+  header_type:
+    type: "string"
+    description: "The type specifier for the block indicating what's happening"
+    default: "header"
+
 steps:
   - run:
       name: "Generate notification template"
@@ -20,7 +25,7 @@ steps:
             \"text\": \"${CIRCLE_PROJECT_REPONAME} ${CIRCLE_BRANCH} job on hold, waiting for approval.\",
             \"blocks\": [
               {
-                \"type\": \"header\",
+                \"type\": \"<< parameters.header_type >>\",
                 \"text\": {
                   \"type\": \"plain_text\",
                   \"text\": \"${CIRCLE_PROJECT_REPONAME} ${CIRCLE_BRANCH} job on hold, waiting for approval. :raised_hand:\",


### PR DESCRIPTION
Mat isn't a fan of the bold messages here (they always trigger his "there's a problem" ops-guy PTSD), and would like to be able to make them stand out less.